### PR TITLE
Option to disable requests SSL certificate validation

### DIFF
--- a/slumber/__init__.py
+++ b/slumber/__init__.py
@@ -98,7 +98,7 @@ class Resource(ResourceAttributesMixin, object):
         if self._store["append_slash"] and not url.endswith("/"):
             url = url + "/"
 
-        resp = self._store["session"].request(method, url, data=data, params=params, headers={"content-type": s.get_content_type()})
+        resp = self._store["session"].request(method, url, data=data, params=params, verify=self._store["verify_ssl"], headers={"content-type": s.get_content_type()})
 
         if 400 <= resp.status_code <= 499:
             raise exceptions.HttpClientError("Client Error %s: %s" % (resp.status_code, url), response=resp, content=resp.content)
@@ -159,12 +159,14 @@ class Resource(ResourceAttributesMixin, object):
 
 class API(ResourceAttributesMixin, object):
 
-    def __init__(self, base_url=None, auth=None, format=None, append_slash=True):
+    def __init__(self, base_url=None, auth=None, format=None, append_slash=True,
+                 verify_ssl=True):
         self._store = {
             "base_url": base_url,
             "format": format if format is not None else "json",
             "append_slash": append_slash,
             "session": requests.session(auth=auth),
+            "verify_ssl": verify_ssl
         }
 
         # Do some Checks for Required Values


### PR DESCRIPTION
By default, requests check SSL certificate.

Sometimes you need to disable this (in my case, on my testing environment)
