### PR TITLE
Making ``Resource._request`` use HTTP accept header when making requests...

### DIFF
--- a/slumber/__init__.py
+++ b/slumber/__init__.py
@@ -98,7 +98,7 @@ class Resource(ResourceAttributesMixin, object):
         if self._store["append_slash"] and not url.endswith("/"):
             url = url + "/"
 
-        resp = self._store["session"].request(method, url, data=data, params=params, headers={"content-type": s.get_content_type()})
+        resp = self._store["session"].request(method, url, data=data, params=params, headers={"content-type": s.get_content_type(), "accept": s.get_content_type()})
 
         if 400 <= resp.status_code <= 499:
             raise exceptions.HttpClientError("Client Error %s: %s" % (resp.status_code, url), response=resp, content=resp.content)

--- a/tests/resource.py
+++ b/tests/resource.py
@@ -32,5 +32,5 @@ class ResourceTestCase(unittest.TestCase):
             "http://example/api/v1/test",
             data=None,
             params=None,
-            headers={"content-type": self.base_resource.get_serializer().get_content_type()}
+            headers={"content-type": self.base_resource.get_serializer().get_content_type(), "accept": self.base_resource.get_serializer().get_content_type()}
         )


### PR DESCRIPTION
....

This fixes a bug where, despite changing the serialization format, the default
serailization format (on the server side, set by tastypie) would be used since
no "Accept" header was set.

By forcing an Accept header for each request, slumber will guarantee (to the
fullest extent possible, anyhow) that the messages both SENT AND RECEIVED from a
tastypie server come back in the desired format.
