### PR TITLE
Support decoded unicode url fragments

### DIFF
--- a/slumber/__init__.py
+++ b/slumber/__init__.py
@@ -15,7 +15,7 @@ def url_join(base, *args):
     """
     scheme, netloc, path, query, fragment = urlparse.urlsplit(base)
     path = path if len(path) else "/"
-    path = posixpath.join(path, *[str(x) for x in args])
+    path = posixpath.join(path, *[('%s' % x) for x in args])
     return urlparse.urlunsplit([scheme, netloc, path, query, fragment])
 
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 import unittest
 import slumber
 
@@ -44,3 +46,17 @@ class UtilsTestCase(unittest.TestCase):
     def test_url_join_trailing_slash(self):
         self.assertEqual(slumber.url_join("http://example.com/", "test/"), "http://example.com/test/")
         self.assertEqual(slumber.url_join("http://example.com/", "test/", "example/"), "http://example.com/test/example/")
+
+    def test_url_join_encoded_unicode(self):
+        expected = "http://example.com/tǝst/"
+
+        url = slumber.url_join("http://example.com/", "tǝst/")
+        self.assertEqual(url, expected)
+
+        url = slumber.url_join("http://example.com/", "tǝst/".decode('utf8').encode('utf8'))
+        self.assertEqual(url, expected)
+
+    def test_url_join_decoded_unicode(self):
+        url = slumber.url_join("http://example.com/", "tǝst/".decode('utf8'))
+        expected = "http://example.com/tǝst/".decode('utf8')
+        self.assertEqual(url, expected)


### PR DESCRIPTION
Ran into an issue when trying to make a decoded unicode request. Switched to string formatting in url_join to support various encodings.

Hope it helps.
