### PR TITLE
Allow Slumber to send default parameters along with every request.

### DIFF
--- a/docs/options.rst
+++ b/docs/options.rst
@@ -29,6 +29,14 @@ To Use Digest or OAuth please consult the requests documentation. The auth
 argument is passed directly to requests and thus works exactly the same way
 and accepts exactly the same arguments.
 
+If you have an API key that you must provide on every request to the api,
+you can specify a dict of default parameters that will always be sent along
+with each call. Specify the defauly parameters like::
+
+    api = slumber.API("http://path/to/my/api/", default_params=dict(key='12345'))
+
+And slumber will always send the default parameters along with each request.
+
 Serializer
 ==========
 

--- a/slumber/__init__.py
+++ b/slumber/__init__.py
@@ -98,6 +98,9 @@ class Resource(ResourceAttributesMixin, object):
         if self._store["append_slash"] and not url.endswith("/"):
             url = url + "/"
 
+        if self._store["default_params"]:
+            params = dict(params.items() + self._store["default_params"].items() if params else self._store["default_params"].items())
+
         resp = self._store["session"].request(method, url, data=data, params=params, headers={"content-type": s.get_content_type(), "accept": s.get_content_type()})
 
         if 400 <= resp.status_code <= 499:
@@ -159,12 +162,13 @@ class Resource(ResourceAttributesMixin, object):
 
 class API(ResourceAttributesMixin, object):
 
-    def __init__(self, base_url=None, auth=None, format=None, append_slash=True, session=None):
+    def __init__(self, base_url=None, auth=None, format=None, append_slash=True, session=None, default_params=None):
         self._store = {
             "base_url": base_url,
             "format": format if format is not None else "json",
             "append_slash": append_slash,
             "session": requests.session(auth=auth) if session is None else session,
+            "default_params": default_params,
         }
 
         # Do some Checks for Required Values


### PR DESCRIPTION
Using an API that requires you to pass an API key along for each call makes for noisy method calls to resources. Slumber now provides a way to take in and remember parameters across multiple calls. Pass in a dict named default_params and those pairs will be sent along with each API call you make.

Documentation updated to explain default_params.
