### PR TITLE
Send Content-Type only if there is data, relative post location

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 docs/_build/*
+*.pyc
+*~

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,5 @@
+.. :changelog:
+
 Changelog
 =========
 

--- a/slumber/__init__.py
+++ b/slumber/__init__.py
@@ -138,7 +138,9 @@ class Resource(ResourceAttributesMixin, object):
                     resource_obj = self(url_override=location)
                 return resource_obj.get(params=kwargs)
             else:
-                return resp.content
+                s = self.get_serializer()
+                
+                return s.loads(resp.content)
         else:
             # @@@ Need to be Some sort of Error Here or Something
             return

--- a/slumber/__init__.py
+++ b/slumber/__init__.py
@@ -138,9 +138,8 @@ class Resource(ResourceAttributesMixin, object):
                     resource_obj = self(url_override=location)
                 return resource_obj.get(params=kwargs)
             else:
-                s = self.get_serializer()
-                
-                return s.loads(resp.content)
+                if resp.content:
+                    return self.get_serializer().loads(resp.content)
         else:
             # @@@ Need to be Some sort of Error Here or Something
             return


### PR DESCRIPTION
Sorry for two fixes in single pull request.

`PUT` and `DELETE` methods should only send `Content-type` header if there request has data.

If `Location` header is not full URL (doesn't start with http/s) it can be passed as `id` parameter and `url_join` function will join `Location` with `base_path`.
