### PR TITLE
fixed the ability to send args to requests via **kwargs

### DIFF
--- a/slumber/__init__.py
+++ b/slumber/__init__.py
@@ -98,8 +98,8 @@ class Resource(ResourceAttributesMixin, object):
         if self._store["append_slash"] and not url.endswith("/"):
             url = url + "/"
 
-        resp = self._store["session"].request(method, url, data=data, params=params, headers={"content-type": s.get_content_type(), "accept": s.get_content_type()})
-
+        resp = self._store["session"].request(method, url, data=data, headers={"content-type": s.get_content_type(), "accept": s.get_content_type()}, **params)
+        
         if 400 <= resp.status_code <= 499:
             raise exceptions.HttpClientError("Client Error %s: %s" % (resp.status_code, url), response=resp, content=resp.content)
         elif 500 <= resp.status_code <= 599:


### PR DESCRIPTION
I noticed that I was unable to send args to requests so I investigated and found that you were sending the kwargs to the params argument to requests.  I changed this to not use the params argument but rather to send **params to requests which in turn is unpacked as valid arguments.

My case was an attempt to send verify=False to requests which was being ignored but after my fix, this works.
