### PR TITLE
requests.session method don't accept parameters and API creation fails

### DIFF
--- a/slumber/__init__.py
+++ b/slumber/__init__.py
@@ -179,11 +179,15 @@ class API(ResourceAttributesMixin, object):
         if serializer is None:
             s = Serializer(default=format)
 
+        if session is None:
+            session = requests.session()
+            session.auth = auth
+
         self._store = {
             "base_url": base_url,
             "format": format if format is not None else "json",
             "append_slash": append_slash,
-            "session": requests.session(auth=auth) if session is None else session,
+            "session": session,
             "serializer": s,
         }
 


### PR DESCRIPTION
Method requests.session() has no arguments on requests 1.0.4. They have removed them on commit https://github.com/kennethreitz/requests/commit/6acce57271efce8c17cea2f1eece943f429e3879#requests/sessions.py
