### PR TITLE
Fix typo "text/text" => "text/plain" in tests/resource.py

### DIFF
--- a/tests/resource.py
+++ b/tests/resource.py
@@ -41,7 +41,7 @@ class ResourceTestCase(unittest.TestCase):
     def test_get_200_text(self):
         r = mock.Mock(spec=requests.Response)
         r.status_code = 200
-        r.headers = {"content-type": "text/text"}
+        r.headers = {"content-type": "text/plain"}
         r.content = "Mocked Content"
 
         self.base_resource._store.update({


### PR DESCRIPTION
Pointed out by @merwork at
https://github.com/msabramo/slumber/commit/f640ec56b42b59979c4cc06df0d1f2ae6c09ebbc#commitcomment-2579532
