### PR TITLE
Allow more complex content types.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ import os.path
 from setuptools import setup, find_packages
 import sys
 
-install_requires = ["requests"]
+install_requires = ["requests>=1.0"]
 
 if sys.version_info < (2, 6):
     install_requires.append("simplejson")

--- a/slumber/__init__.py
+++ b/slumber/__init__.py
@@ -120,9 +120,11 @@ class Resource(ResourceAttributesMixin, object):
             try:
                 stype = s.get_serializer(content_type=content_type)
             except exceptions.SerializerNotAvailable:
+                stype = s.get_serializer()
+            try:
+                return stype.loads(resp.content)
+            except:
                 return resp.content
-
-            return stype.loads(resp.content)
         else:
             return resp.content
 


### PR DESCRIPTION
We use Content-type headers that look like this:

Content-Type: application/vnd.api.v1+json; charset=utf-8

and curently slumber barfs on these, refusing to decode.  This change
allows you to specify, say, format='json' when initializing the API
object and deserialize properly.

I'm not sure if this is the totally right spot for this code, but I wanted
to bring this to ya'lls attention.
