### PR TITLE
Error with 204 response having a content-type.

### DIFF
--- a/slumber/__init__.py
+++ b/slumber/__init__.py
@@ -120,6 +120,8 @@ class Resource(ResourceAttributesMixin, object):
 
     def _try_to_serialize_response(self, resp):
         s = self._store["serializer"]
+        if resp.status_code in [204, 205]:
+            return
 
         if resp.headers.get("content-type", None):
             content_type = resp.headers.get("content-type").split(";")[0].strip()

--- a/tests/resource.py
+++ b/tests/resource.py
@@ -263,6 +263,7 @@ class ResourceTestCase(unittest.TestCase):
         })
 
         resp = mock.Mock(spec=requests.Response)
+        resp.status_code = 200
         resp.headers = {"content-type": "application/json; charset=utf-8"}
         resp.content = '{"foo": "bar"}'
 
@@ -270,3 +271,17 @@ class ResourceTestCase(unittest.TestCase):
 
         if not isinstance(r, dict):
             self.fail("Serialization did not take place")
+    
+    def test_post_204_json(self):
+        resp = mock.Mock(spec=requests.Response)
+        resp.status_code = 204
+        resp.headers = {"content-type": "application/json"}
+        resp.content = None
+
+        self.base_resource._store.update({
+            "session": mock.Mock(spec=requests.Session),
+            "serializer": slumber.serialize.Serializer(),
+        })
+        self.base_resource._store["session"].request.return_value = resp
+
+        self.assertEqual(self.base_resource.post(), None)


### PR DESCRIPTION
As per RFC 2616:
##### [10.2.5](http://tools.ietf.org/html/rfc2616#section-10.2.5) 204 No Content:
> The response MAY include ... metainformation in the form of entity-headers

##### [7.1](http://tools.ietf.org/html/rfc2616#section-7.1) Entity Header Fields
Content-Type is an entity-header.

A 204 response can have a content type.