### PR TITLE
Python 2.6 and 3.x support fixes and enhanced versions testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,12 @@ language: python
 python:
   - 2.6
   - 2.7
-  - 3.1
+  # 3.1 # Travis no longer supports Python 3.1
   - 3.2
-install: pip install -r requirements.txt && pip install -r requirements-test.txt
-script: python setup.py test
+  - 3.3
+  - pypy
+install:
+  - pip install -r requirements.txt && pip install -r requirements-test.txt
+  - case `python -V 2>&1` in *2.6*) pip install unittest2;; esac
+script:
+  - python setup.py test

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,1 +1,2 @@
 mock
+tox

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 requests
+six

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 import os
 from setuptools import setup
 
-install_requires = ["requests"]
+install_requires = ["requests", "six"]
 
 base_dir = os.path.dirname(os.path.abspath(__file__))
 

--- a/slumber/__init__.py
+++ b/slumber/__init__.py
@@ -3,6 +3,7 @@ try:
     from urllib.parse import urlsplit, urlunsplit
 except ImportError:
     from urlparse import urlsplit, urlunsplit
+from six import u, b, PY3, iteritems
 
 import requests
 
@@ -37,7 +38,7 @@ class ResourceAttributesMixin(object):
             raise AttributeError(item)
 
         kwargs = {}
-        for key, value in self._store.iteritems():
+        for key, value in iteritems(self._store):
             kwargs[key] = value
 
         kwargs.update({"base_url": url_join(self._store["base_url"], item)})
@@ -72,7 +73,7 @@ class Resource(ResourceAttributesMixin, object):
             return self
 
         kwargs = {}
-        for key, value in self._store.iteritems():
+        for key, value in iteritems(self._store):
             kwargs[key] = value
 
         if id is not None:

--- a/slumber/__init__.py
+++ b/slumber/__init__.py
@@ -1,5 +1,8 @@
 import posixpath
-import urlparse
+try:
+    from urllib.parse import urlsplit, urlunsplit
+except ImportError:
+    from urlparse import urlsplit, urlunsplit
 
 import requests
 
@@ -13,10 +16,10 @@ def url_join(base, *args):
     """
     Helper function to join an arbitrary number of url segments together.
     """
-    scheme, netloc, path, query, fragment = urlparse.urlsplit(base)
+    scheme, netloc, path, query, fragment = urlsplit(base)
     path = path if len(path) else "/"
     path = posixpath.join(path, *[('%s' % x) for x in args])
-    return urlparse.urlunsplit([scheme, netloc, path, query, fragment])
+    return urlunsplit([scheme, netloc, path, query, fragment])
 
 
 class ResourceAttributesMixin(object):

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,9 +1,9 @@
 import os.path
-try:
-    import unittest2 as unittest
-except ImportError:
+import sys
+if sys.version_info >= (2, 7):
     import unittest
-
+else:
+    import unittest2 as unittest
 
 def get_tests():
     start_dir = os.path.dirname(__file__)

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,5 +1,8 @@
 import os.path
-import unittest
+try:
+    import unittest2 as unittest
+except ImportError:
+    import unittest
 
 
 def get_tests():

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -49,24 +49,97 @@ class UtilsTestCase(unittest.TestCase):
         self.assertEqual(slumber.url_join("http://example.com/", "test/", "example/"), "http://example.com/test/example/")
 
     def test_url_join_encoded_unicode(self):
-        expected = six.u("http://example.com/tǝst/")
-
-        if expected.__class__.__name__ == "unicode":
+        # u"ǝ" == u"\u01dd", u"\u01dd".encode('utf-8') == b"\xc7\x9d"
+        expected = six.u("http://example.com/r\u01dd/test")
+        if (isinstance(expected, six.text_type)):
             expected = expected.encode('utf-8')
 
-        url = slumber.url_join("http://example.com/", six.u("tǝst/"))
-        if url.__class__.__name__ == "unicode":
+        url = slumber.url_join(bytearray(six.b("http://example.com/r\xc7\x9d")),
+                               six.b("test"))
+        if (isinstance(url, six.text_type)):
             url = url.encode('utf-8')
 
         self.assertEqual(url, expected)
 
-        url = slumber.url_join("http://example.com/", six.u("tǝst/"))
-        if url.__class__.__name__ == "unicode":
+        url = slumber.url_join(six.b("http://example.com/r\xc7\x9d"),
+                               bytearray(six.b("test")))
+        if (isinstance(url, six.text_type)):
+            url = url.encode('utf-8')
+
+        self.assertEqual(url, expected)
+
+        # check that non-ASCII args with bytes base URL raise TypeError
+        self.assertRaises(TypeError, slumber.url_join,
+                          six.b("http://example.com"), six.b("r\xc7\x9d"))
+            
+        expected = six.u("http://example.com/re/test")
+        if (isinstance(expected, six.text_type)):
+            expected = expected.encode('utf-8')
+
+        url = slumber.url_join(bytearray(six.b("http://example.com/re")),
+                               bytearray(six.b("test")))
+        if (isinstance(url, six.text_type)):
+            url = url.encode('utf-8')
+
+        self.assertEqual(url, expected)
+
+        url = slumber.url_join(six.b("http://example.com"),
+                               six.b("re/test"))
+        if (isinstance(url, six.text_type)):
+            url = url.encode('utf-8')
+
+        self.assertEqual(url, expected)
+
+    def test_url_join_mixed_unicode(self):
+        # u"ǝ" == u"\u01dd", u"\u01dd".encode('utf-8') == b"\xc7\x9d"
+        expected = six.u("http://example.com/r\u01dd/te/st")
+        if (isinstance(expected, six.text_type)):
+            expected = expected.encode('utf-8')
+
+        url = slumber.url_join(six.b("http://example.com/r\xc7\x9d"),
+                               bytearray(six.b("te")),
+                               six.u("st"))
+        if (isinstance(url, six.text_type)):
+            url = url.encode('utf-8')
+
+        self.assertEqual(url, expected)
+
+        url = slumber.url_join(six.u("http://example.com"),
+                               six.u("r\u01dd/te"),
+                               bytearray(six.b("st")))
+        if (isinstance(url, six.text_type)):
+            url = url.encode('utf-8')
+
+        self.assertEqual(url, expected)
+
+        # check that non-ASCII args needing conversion raise TypeError
+        self.assertRaises(TypeError, slumber.url_join,
+                          six.u("http://example.com"), six.b("r\xc7\x9d"))
+
+        self.assertRaises(TypeError, slumber.url_join,
+                          six.b("http://example.com"), six.u("r\u01dd"))
+
+        expected = six.u("http://example.com/te/st")
+        if (isinstance(expected, six.text_type)):
+            expected = expected.encode('utf-8')
+
+        url = slumber.url_join(bytearray(six.b("http://example.com/")),
+                               six.b("te"),
+                               six.u("st"))
+        if (isinstance(url, six.text_type)):
+            url = url.encode('utf-8')
+
+        self.assertEqual(url, expected)
+
+        url = slumber.url_join(six.u("http://example.com/"),
+                               six.u("te"),
+                               six.b("st"))
+        if (isinstance(url, six.text_type)):
             url = url.encode('utf-8')
 
         self.assertEqual(url, expected)
 
     def test_url_join_decoded_unicode(self):
-        url = slumber.url_join("http://example.com/", six.u("tǝst/"))
-        expected = six.u("http://example.com/tǝst/")
+        url = slumber.url_join(six.u("http://examplǝ.com/"), six.u("tǝst/"))
+        expected = six.u("http://examplǝ.com/tǝst/")
         self.assertEqual(url, expected)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -2,6 +2,7 @@
 
 import unittest
 import slumber
+import six
 
 
 class UtilsTestCase(unittest.TestCase):
@@ -48,15 +49,24 @@ class UtilsTestCase(unittest.TestCase):
         self.assertEqual(slumber.url_join("http://example.com/", "test/", "example/"), "http://example.com/test/example/")
 
     def test_url_join_encoded_unicode(self):
-        expected = "http://example.com/tǝst/"
+        expected = six.u("http://example.com/tǝst/")
 
-        url = slumber.url_join("http://example.com/", "tǝst/")
+        if expected.__class__.__name__ == "unicode":
+            expected = expected.encode('utf-8')
+
+        url = slumber.url_join("http://example.com/", six.u("tǝst/"))
+        if url.__class__.__name__ == "unicode":
+            url = url.encode('utf-8')
+
         self.assertEqual(url, expected)
 
-        url = slumber.url_join("http://example.com/", "tǝst/".decode('utf8').encode('utf8'))
+        url = slumber.url_join("http://example.com/", six.u("tǝst/"))
+        if url.__class__.__name__ == "unicode":
+            url = url.encode('utf-8')
+
         self.assertEqual(url, expected)
 
     def test_url_join_decoded_unicode(self):
-        url = slumber.url_join("http://example.com/", "tǝst/".decode('utf8'))
-        expected = "http://example.com/tǝst/".decode('utf8')
+        url = slumber.url_join("http://example.com/", six.u("tǝst/"))
+        expected = six.u("http://example.com/tǝst/")
         self.assertEqual(url, expected)

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py26, py27, py32, py33, pypy
+envlist = py26, py27, py31, py32, py33, pypy
 
 [testenv]
 commands =

--- a/tox.ini
+++ b/tox.ini
@@ -9,9 +9,11 @@ envlist = py26, py27, py32, py33, pypy
 [testenv]
 commands =
     pip install -r requirements.txt
-    pip install -r requirements-test.txt
     python setup.py test
+deps =
+    mock
 
 [testenv:py26]
 deps =
+    mock
     unittest2

--- a/tox.ini
+++ b/tox.ini
@@ -4,10 +4,14 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py27, pypy
+envlist = py26, py27, py32, py33, pypy
 
 [testenv]
 commands =
     pip install -r requirements.txt
     pip install -r requirements-test.txt
     python setup.py test
+
+[testenv:py26]
+deps =
+    unittest2


### PR DESCRIPTION
This pull request is mostly a superset of [Bernardo Heynemann](https://github.com/heynemann)'s PR https://github.com/dstufft/slumber/pull/70 (I omitted the last two commits in that PR as they seemed off-topic, worthwhile as they might otherwise be).

In addition to his fixes for 2.6 and py3k bugs, using the excellent `six` compatibility library, I enhanced the testing setup for slumber, updating the `.travis.yml` configuration to add testing for all the Python versions (except 2.5) that it supports, and as you can see from the [Travis report](https://travis-ci.org/dupuy/slumber/builds/8684058) on this PR, all tests are passing on all those versions.  I also made some tweaks to the `tox.ini` he created, so that it doesn't install tox itself (and all of its dependencies) in the virtualenvs that it creates for testing slumber on different Python versions, and so that it tests Python 3.1 if available (Travis no longer supports Python 3.1, so it's commented out in `.travis.yml`).  

I also fixed some other Py3K issues that I ran into while using slumber (before I saw his PR).  In particular:
- Use of `iteritems()` method in several places was not compatible with py3k; I used `six.iteritems()` function, which is defined appropriately for Python 2 or 3.
- The url_join() function did not properly concatenate path components passed as bytes in py3k - they would be formatted as `/b'url-path-comp'/` rather than as `/url-path-comp/`.  Passing them as bytearray made it worse, as they would then be formatted as `/bytearray(b'url-path-comp')/`!  There were also some latent issues with encoding compatibility and mixing Unicode and bytes, where urlsplit or urlunsplit could raise `UnicodeDecodeError` exceptions, and other cases where users could pass in bytes data with incompatible encodings that would not raise exceptions.

For the second issue, I added several cases to the test suite for url_join, including checks that `TypeError` exceptions are raised for potentially incompatibly encoded data passed to url_join (if you need non-ASCII data in the extra arguments, you need to pass them (and the base URL) as Unicode, not bytes).

In @merwok's comment on PR #70, issue https://github.com/dstufft/slumber/issues/56 is mentioned, specifically the possibility of syncing `tox.ini` and `.travis.yml` using the panci tool.  I installed panci and ran it against those files in this PR, but I found the output to be somewhat inferior to the versions of those files in this PR; the resulting files lose functionality and/or cause test failures, and I didn't feel like fixing panci too.

``` diff
--- .travis.yml 2013-06-05 02:16:45 -0400
+++ tox-to-travis.yml   2013-07-03 01:16:43 -0400
@@ -1,13 +1,14 @@
 language: python
 python:
-  - 2.6
-  - 2.7
-  # 3.1 # Travis no longer supports Python 3.1
-  - 3.2
-  - 3.3
+- '2.6'
+- '2.7'
+- '3.1'
+- '3.2'
+- '3.3'
   - pypy
-install:
-  - pip install -r requirements.txt && pip install -r requirements-test.txt
-  - case `python -V 2>&1` in *2.6*) pip install unittest2;; esac
-script:
-  - python setup.py test
+script: '
+
+  pip install -r requirements.txt
+
+  python setup.py test'
+
```

``` diff
--- tox.ini     2013-07-03 00:32:56 -0400
+++ travis-to-tox.ini   2013-07-03 01:16:52 -0400
@@ -4,16 +4,11 @@
 # and then run "tox" from this directory.

 [tox]
-envlist = py26, py27, py31, py32, py33, pypy
+envlist = py26, py27, py32, py33, pypy

 [testenv]
 commands =
-    pip install -r requirements.txt
+    pip install -r requirements.txt && pip install -r requirements-test.txt
+    case `python -V 2>&1` in *2.6*) pip install unittest2;; esac
     python setup.py test
-deps =
-    mock

-[testenv:py26]
-deps =
-    mock
-    unittest2
```

If you really want to generate one from the other, generate `tox.ini` from `.travis.yml` since the only lost functionality is Python 3.1 testing, and the useless installation of tox and its dependencies inside the virtualenvs for testing slumber (which I fixed in d534651) is annoying but harmless, and I don't think you'll get any test failures.
