### PR TITLE
POST returns the dictionary representation of the response again.

### DIFF
--- a/slumber/__init__.py
+++ b/slumber/__init__.py
@@ -127,8 +127,17 @@ class Resource(ResourceAttributesMixin, object):
             try:
                 stype = s.get_serializer(content_type=content_type)
             except exceptions.SerializerNotAvailable:
-                return resp.content
+                if 'location' in resp.headers:
+                    resource_obj = self(url_override=resp.headers['location'])
 
+                    # restore the old behavior
+                    return resource_obj.get()
+
+                    # or just return the location?
+                    #return resp.headers['location']
+                else:
+                    return resp.content
+            
             return stype.loads(resp.content)
         else:
             return resp.content


### PR DESCRIPTION
I restored the old behavior but I'm not sure this is the correct approach either. Need to do something with the location but returning the url doesn't seem ideal either given slumber has no exposed way to return the object from the location url.
