### PR TITLE
added logging to HTTP errors w/ url, status and response content

### DIFF
--- a/slumber/__init__.py
+++ b/slumber/__init__.py
@@ -9,7 +9,16 @@ from slumber.serialize import Serializer
 
 __all__ = ["Resource", "API"]
 
-logger = logging.getLogger("slumber")
+
+try:  # Python 2.7+
+    from logging import NullHandler
+except ImportError:
+    class NullHandler(logging.Handler):
+        def emit(self, record):
+            pass
+
+logger = logging.getLogger(__name__)
+logger.addHandler(NullHandler())
 
 
 def url_join(base, *args):


### PR DESCRIPTION
This change adds a "slumber" logger and uses it to emit ERROR level messages w/ the URL, HTTP Status and response content in the event of an HTTP error. This should make it easier to debug server errors on the client side.
