### PR TITLE
create a specialized error for 404s

### DIFF
--- a/slumber/__init__.py
+++ b/slumber/__init__.py
@@ -105,7 +105,8 @@ class Resource(ResourceAttributesMixin, object):
         resp = self._store["session"].request(method, url, data=data, params=params, files=files, headers=headers)
 
         if 400 <= resp.status_code <= 499:
-            raise exceptions.HttpClientError("Client Error %s: %s" % (resp.status_code, url), response=resp, content=resp.content)
+            exception_class = exceptions.Http404Error if resp.status_code == 404 else exceptions.HttpClientError
+            raise exception_class("Client Error %s: %s" % (resp.status_code, url), response=resp, content=resp.content)
         elif 500 <= resp.status_code <= 599:
             raise exceptions.HttpServerError("Server Error %s: %s" % (resp.status_code, url), response=resp, content=resp.content)
 

--- a/slumber/exceptions.py
+++ b/slumber/exceptions.py
@@ -21,6 +21,12 @@ class HttpClientError(SlumberHttpBaseException):
     """
 
 
+class Http404Error(HttpClientError):
+    """
+    Called when the server sends a 404 error.
+    """
+
+
 class HttpServerError(SlumberHttpBaseException):
     """
     Called when the server tells us there was a server error (5xx).


### PR DESCRIPTION
NOTE: If #77 is accepted, I'm happy to merge this code with that one.

A missing object on a resource is a common error. Often times your app
will want to handle this case differently than other errors. Currently,
you have to catch the exception, test the response.status_code, and
then re-raise if it's not 404. e.g.,

```python
api = slumber.API(...)
try:
    api.resource(some_id).get()
except slumber.exceptions.HttpClientError as e:
    if e.resp.status_code == 404:
        # do something 404-specific, perhaps raising a Http404 in Django
    else:
        raise   # re-raise the original exception
```

This patch creates a new error (Http404Error) that subclasses
HttpClientError. It makes the use case much easier on users:

```python
api = slumber.API(...)
try:
    api.resource(some_id).get()
except slumber.exceptions.Http404Error:
    # do something 404-specific
```