### PR TITLE
Add auth to request session if it's passed. Fixes #79

### DIFF
--- a/slumber/__init__.py
+++ b/slumber/__init__.py
@@ -190,6 +190,8 @@ class API(ResourceAttributesMixin, object):
 
         if session is None:
             session = requests.session()
+
+        if auth is not None:
             session.auth = auth
 
         self._store = {


### PR DESCRIPTION
Hello again, 

idea behind second if:
if we pass authorized `session` and no `auth` we wont set `session.auth` to `None`, in case `auth` is passed we use it.  

Alex. 