### PR TITLE
fix for binary requests response content in py3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,6 @@ docs/_build/*
 slumber.egg-info
 build/
 .coverage
+/.project
+/.pydevproject
+/.settings/

--- a/slumber/__init__.py
+++ b/slumber/__init__.py
@@ -119,6 +119,11 @@ class Resource(ResourceAttributesMixin, object):
             except exceptions.SerializerNotAvailable:
                 return resp.content
 
+            if type(resp.content) == bytes:
+                try:
+                    return stype.loads(resp.content.decode())
+                except:
+                    return resp.content
             return stype.loads(resp.content)
         else:
             return resp.content

--- a/tests/resource.py
+++ b/tests/resource.py
@@ -355,3 +355,32 @@ class ResourceTestCase(unittest.TestCase):
 
     def test_url(self):
         self.assertEqual(self.base_resource.url(), "http://example/api/v1/test")
+
+    def test_get_200_json_py3(self):
+        r = mock.Mock(spec=requests.Response)
+        r.status_code = 200
+        r.headers = {"content-type": "application/json"}
+        r.content = b'{"result": ["a", "b", "c"]}'
+
+        self.base_resource._store.update({
+            "session": mock.Mock(spec=requests.Session),
+            "serializer": slumber.serialize.Serializer(),
+        })
+        self.base_resource._store["session"].request.return_value = r
+
+        resp = self.base_resource._request("GET")
+
+        self.assertTrue(resp is r)
+        self.assertEqual(resp.content, r.content)
+
+        self.base_resource._store["session"].request.assert_called_once_with(
+            "GET",
+            "http://example/api/v1/test",
+            data=None,
+            files=None,
+            params=None,
+            headers={"content-type": self.base_resource._store["serializer"].get_content_type(), "accept": self.base_resource._store["serializer"].get_content_type()}
+        )
+
+        resp = self.base_resource.get()
+        self.assertEqual(resp['result'], ['a', 'b', 'c'])

--- a/tests/serializer.py
+++ b/tests/serializer.py
@@ -7,7 +7,6 @@ class ResourceTestCase(unittest.TestCase):
     def setUp(self):
         self.data = {
             "foo": "bar",
-            "baz": [1, 2, 3]
         }
 
     def test_json_get_serializer(self):
@@ -22,11 +21,11 @@ class ResourceTestCase(unittest.TestCase):
             "text/x-json",
         ]:
             serializer = s.get_serializer(content_type=content_type)
-            self.assertIsInstance(serializer, slumber.serialize.JsonSerializer,
-                                  "content_type %s should produce a JsonSerializer")
+            self.assertEqual(type(serializer), slumber.serialize.JsonSerializer,
+                             "content_type %s should produce a JsonSerializer")
 
         result = serializer.dumps(self.data)
-        self.assertEqual(result, '{"foo": "bar", "baz": [1, 2, 3]}')
+        self.assertEqual(result, '{"foo": "bar"}')
         self.assertEqual(self.data, serializer.loads(result))
 
     def test_yaml_get_serializer(self):
@@ -37,9 +36,9 @@ class ResourceTestCase(unittest.TestCase):
             "text/yaml",
         ]:
             serializer = s.get_serializer(content_type=content_type)
-            self.assertIsInstance(serializer, slumber.serialize.YamlSerializer,
-                                  "content_type %s should produce a YamlSerializer")
+            self.assertEqual(type(serializer), slumber.serialize.YamlSerializer,
+                             "content_type %s should produce a YamlSerializer")
 
         result = serializer.dumps(self.data)
-        self.assertEqual(result, "baz: [1, 2, 3]\nfoo: bar\n")
+        self.assertEqual(result, "{foo: bar}\n")
         self.assertEqual(self.data, serializer.loads(result))

--- a/tests/serializer.py
+++ b/tests/serializer.py
@@ -4,15 +4,42 @@ import slumber.serialize
 
 
 class ResourceTestCase(unittest.TestCase):
+    def setUp(self):
+        self.data = {
+            "foo": "bar",
+            "baz": [1, 2, 3]
+        }
 
     def test_json_get_serializer(self):
         s = slumber.serialize.Serializer()
 
+        serializer = None
         for content_type in [
-                                "application/json",
-                                "application/x-javascript",
-                                "text/javascript",
-                                "text/x-javascript",
-                                "text/x-json",
-                            ]:
-            s.get_serializer(content_type=content_type)
+            "application/json",
+            "application/x-javascript",
+            "text/javascript",
+            "text/x-javascript",
+            "text/x-json",
+        ]:
+            serializer = s.get_serializer(content_type=content_type)
+            self.assertIsInstance(serializer, slumber.serialize.JsonSerializer,
+                                  "content_type %s should produce a JsonSerializer")
+
+        result = serializer.dumps(self.data)
+        self.assertEqual(result, '{"foo": "bar", "baz": [1, 2, 3]}')
+        self.assertEqual(self.data, serializer.loads(result))
+
+    def test_yaml_get_serializer(self):
+        s = slumber.serialize.Serializer()
+
+        serializer = None
+        for content_type in [
+            "text/yaml",
+        ]:
+            serializer = s.get_serializer(content_type=content_type)
+            self.assertIsInstance(serializer, slumber.serialize.YamlSerializer,
+                                  "content_type %s should produce a YamlSerializer")
+
+        result = serializer.dumps(self.data)
+        self.assertEqual(result, "baz: [1, 2, 3]\nfoo: bar\n")
+        self.assertEqual(self.data, serializer.loads(result))

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py26, py27, py32, py33, py34, pypy
+envlist = py26, py27, py32, py33, py34, pypy, report
 
 [testenv]
 commands = 
@@ -12,4 +12,11 @@ commands =
     pip install -r requirements-test.txt
     pip install coveralls
     coverage run --source=slumber setup.py test
-        
+    
+[testenv:report]
+basepython = python3.4
+commands =
+    coverage combine
+    coverage report -m
+usedevelop = true
+deps = coverage==3.7.1


### PR DESCRIPTION
The requests lib on python3 returns response.content as ```bytes``` type.  This is not accounted for in any of the current tests, thus incorrectly purporting python3 compatibility.

This PR includes:
1. A test (```test_get_200_json_py3```) that is identical to ```test_get_200_json``` except that the mock response content is binary data
2. A fix for ```_try_to_serialize_response``` that checks for a binary response and attempts to decode it
3. some ignores and a coverage report item in the tox config
