### PR TITLE
Use simplejson to handle both strings and bytes without pain

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ import os
 import sys
 from setuptools import setup
 
-install_requires = ["requests"]
+install_requires = ["requests", "simplejson"]
 tests_require = ["mock"]
 
 base_dir = os.path.dirname(os.path.abspath(__file__))

--- a/slumber/serialize.py
+++ b/slumber/serialize.py
@@ -1,14 +1,11 @@
+import simplejson as json
+
 from slumber import exceptions
 
 _SERIALIZERS = {
     "json": True,
     "yaml": True,
 }
-
-try:
-    import json
-except ImportError:
-    _SERIALIZERS["json"] = False
 
 try:
     import yaml


### PR DESCRIPTION
Hi Samuel! Me again:)

The last fix -- lets use `simplejson`, thus we can work with both `strings` and `bytes` without any troubles. And we wont need huge `six` as a dependency. 

Regards from Moscow and happy New Year,
Alex