### PR TITLE
Add missing tests_require requirement (unittest2)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ import sys
 from setuptools import setup
 
 install_requires = ["requests"]
-tests_require = ["mock"]
+tests_require = ["mock", "unittest2"]
 
 base_dir = os.path.dirname(os.path.abspath(__file__))
 


### PR DESCRIPTION
unittest2 is listed in test-requirements.txt, but is missing from tests_require in setup.py. It may be worth reading the contests of test_requirements.txt to populate tests_require, but I'd leave that design decision to you :) cc @dstufft