### PR TITLE
Deps as deps in tox.ini

### DIFF
--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,2 +1,3 @@
 mock
 unittest2
+pyyaml

--- a/tox.ini
+++ b/tox.ini
@@ -7,16 +7,17 @@
 envlist = py26, py27, py32, py33, py34, pypy, report
 
 [testenv]
-commands = 
-    pip install -r requirements.txt
-    pip install -r requirements-test.txt
-    pip install coveralls
+deps =
+    -r./requirements.txt
+    -r./requirements-test.txt
+    coverage==3.7.1
+    coveralls
+commands =
     coverage run --source=slumber setup.py test
-    
+
 [testenv:report]
 basepython = python3.4
 commands =
     coverage combine
     coverage report -m
 usedevelop = true
-deps = coverage==3.7.1


### PR DESCRIPTION
The trick one must know is that the "-r" option must be one word in "deps", and I like to add "./" to still have it readable. Also, I had a failure due to pyyaml not installed into a pristine virtualenv.