### PR TITLE
Add support for client certificate and custom headers

### DIFF
--- a/slumber/__init__.py
+++ b/slumber/__init__.py
@@ -96,7 +96,7 @@ class Resource(ResourceAttributesMixin, object):
             if data is not None:
                 data = serializer.dumps(data)
 
-        resp = self._store["session"].request(method, url, data=data, params=params, files=files, headers=headers)
+        resp = self._store["session"].request(method, url, data=data, params=params, files=files, headers=headers, cert=cert)
 
         if 400 <= resp.status_code <= 499:
             exception_class = exceptions.HttpNotFoundError if resp.status_code == 404 else exceptions.HttpClientError

--- a/slumber/__init__.py
+++ b/slumber/__init__.py
@@ -85,6 +85,8 @@ class Resource(ResourceAttributesMixin, object):
 
     def _request(self, method, data=None, files=None, params=None):
         serializer = self._store["serializer"]
+        cert       = self._store["cert"] if 'cert' in self._store else None
+        headers    = self._store["headers"] if 'headers' in self._store else None
         url = self.url()
 
         headers = {"accept": serializer.get_content_type()}
@@ -192,7 +194,7 @@ class API(ResourceAttributesMixin, object):
 
     resource_class = Resource
 
-    def __init__(self, base_url=None, auth=None, format=None, append_slash=True, session=None, serializer=None):
+    def __init__(self, base_url=None, auth=None, format=None, append_slash=True, session=None, serializer=None, headers=None, cert=None):
         if serializer is None:
             serializer = Serializer(default=format)
 
@@ -208,6 +210,8 @@ class API(ResourceAttributesMixin, object):
             "append_slash": append_slash,
             "session": session,
             "serializer": serializer,
+            "headers": headers,
+            "cert": cert,
         }
 
         # Do some Checks for Required Values

--- a/tests/resource.py
+++ b/tests/resource.py
@@ -36,6 +36,7 @@ class ResourceTestCase(unittest.TestCase):
             data=None,
             files=None,
             params=None,
+            cert=None,
             headers={"content-type": self.base_resource._store["serializer"].get_content_type(), "accept": self.base_resource._store["serializer"].get_content_type()}
         )
 
@@ -65,6 +66,7 @@ class ResourceTestCase(unittest.TestCase):
             data=None,
             files=None,
             params=None,
+            cert=None,
             headers={"content-type": self.base_resource._store["serializer"].get_content_type(), "accept": self.base_resource._store["serializer"].get_content_type()}
         )
 
@@ -94,6 +96,7 @@ class ResourceTestCase(unittest.TestCase):
             data=None,
             files=None,
             params=None,
+            cert=None,
             headers={"content-type": self.base_resource._store["serializer"].get_content_type(),
                      "accept": self.base_resource._store["serializer"].get_content_type()}
         )
@@ -127,6 +130,7 @@ class ResourceTestCase(unittest.TestCase):
             data=None,
             files=None,
             params=None,
+            cert=None,
             headers={"content-type": self.base_resource._store["serializer"].get_content_type(),
                      "accept": self.base_resource._store["serializer"].get_content_type()}
         )
@@ -162,6 +166,7 @@ class ResourceTestCase(unittest.TestCase):
             data=None,
             files=None,
             params=None,
+            cert=None,
             headers={"content-type": self.base_resource._store["serializer"].get_content_type(), "accept": self.base_resource._store["serializer"].get_content_type()}
         )
 
@@ -191,6 +196,7 @@ class ResourceTestCase(unittest.TestCase):
             data=None,
             files=None,
             params=None,
+            cert=None,
             headers={"content-type": self.base_resource._store["serializer"].get_content_type(), "accept": self.base_resource._store["serializer"].get_content_type()}
         )
 
@@ -225,6 +231,7 @@ class ResourceTestCase(unittest.TestCase):
             data=None,
             files=None,
             params=None,
+            cert=None,
             headers={"content-type": self.base_resource._store["serializer"].get_content_type(), "accept": self.base_resource._store["serializer"].get_content_type()}
         )
 
@@ -254,6 +261,7 @@ class ResourceTestCase(unittest.TestCase):
             data=None,
             files=None,
             params=None,
+            cert=None,
             headers={"content-type": self.base_resource._store["serializer"].get_content_type(), "accept": self.base_resource._store["serializer"].get_content_type()}
         )
 
@@ -288,6 +296,7 @@ class ResourceTestCase(unittest.TestCase):
             data=None,
             files=None,
             params=None,
+            cert=None,
             headers={"content-type": self.base_resource._store["serializer"].get_content_type(), "accept": self.base_resource._store["serializer"].get_content_type()}
         )
 
@@ -317,6 +326,7 @@ class ResourceTestCase(unittest.TestCase):
             data=None,
             files=None,
             params=None,
+            cert=None,
             headers={"content-type": self.base_resource._store["serializer"].get_content_type(), "accept": self.base_resource._store["serializer"].get_content_type()}
         )
 
@@ -376,6 +386,7 @@ class ResourceTestCase(unittest.TestCase):
             data=None,
             files=None,
             params=None,
+            cert=None,
             headers={"content-type": self.base_resource._store["serializer"].get_content_type(), "accept": self.base_resource._store["serializer"].get_content_type()}
         )
 
@@ -487,6 +498,7 @@ class ResourceTestCase(unittest.TestCase):
             data=None,
             files=None,
             params=None,
+            cert=None,
             headers={"content-type": self.base_resource._store["serializer"].get_content_type(), "accept": self.base_resource._store["serializer"].get_content_type()}
         )
 


### PR DESCRIPTION
This change will allow one to pass in custom headers and a client certificate at instantiation time.

I have also updated the existing unit tests.
