### PR TITLE
Use requests' guess_json_utf() to specify an encoding for decode()

### DIFF
--- a/slumber/__init__.py
+++ b/slumber/__init__.py
@@ -126,7 +126,8 @@ class Resource(ResourceAttributesMixin, object):
 
             if type(resp.content) == bytes:
                 try:
-                    return stype.loads(resp.content.decode())
+                    encoding = requests.utils.guess_json_utf(resp.content)
+                    return stype.loads(resp.content.decode(encoding))
                 except:
                     return resp.content
             return stype.loads(resp.content)

--- a/slumber/serialize.py
+++ b/slumber/serialize.py
@@ -45,7 +45,7 @@ class JsonSerializer(BaseSerializer):
     key = "json"
 
     def loads(self, data):
-        return json.loads(str(data))
+        return json.loads(data)
 
     def dumps(self, data):
         return json.dumps(data)

--- a/tests/resource.py
+++ b/tests/resource.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 import sys
 import mock
 import requests
@@ -512,3 +513,33 @@ class ResourceTestCase(unittest.TestCase):
                     },
                 params=getparams,
                 data=None)
+
+    def test_unicode_decodable_response(self):
+        r = mock.Mock(spec=requests.Response)
+        r.status_code = 200
+        r.content = '{"result": "Préparatoire"}'
+        r.headers = {"content-type": "application/json"}
+
+        self.base_resource._store.update({
+            "session": mock.Mock(spec=requests.Session),
+            "serializer": slumber.serialize.Serializer(),
+        })
+        self.base_resource._store["session"].request.return_value = r
+
+        resp = self.base_resource._request("POST")
+
+        self.assertTrue(resp is r)
+        self.assertEqual(resp.content, r.content)
+
+        self.base_resource._store["session"].request.assert_called_once_with(
+            "POST",
+            "http://example/api/v1/test",
+            data=None,
+            files=None,
+            params=None,
+            headers={"content-type": self.base_resource._store["serializer"].get_content_type(), "accept": self.base_resource._store["serializer"].get_content_type()}
+        )
+
+        resp = self.base_resource.post(data={'foo': 'bar'})
+        expected = b'Pr\xc3\xa9paratoire'.decode('utf8')
+        self.assertEqual(resp['result'], expected)


### PR DESCRIPTION
If a response's content contains Unicode, Slumber will attempt to decode it without specifying an encoding. The lack of an encoding causes an error.

This PR addresses this issue by using an approach similar to [that used by requests itself](https://github.com/kennethreitz/requests/blob/master/requests/models.py#L792): using request's `guess_json_utf()` helper to detect which encoding to use, and then specifying the proper encoding to `decode()`.