### PR TITLE
Separate serializers

### DIFF
--- a/slumber/serialize.py
+++ b/slumber/serialize.py
@@ -1,8 +1,11 @@
+import urllib
+import urlparse
 from slumber import exceptions
 
 _SERIALIZERS = {
     "json": True,
     "yaml": True,
+    "formdata": True,
 }
 
 try:
@@ -63,6 +66,20 @@ class YamlSerializer(BaseSerializer):
         return yaml.dump(data)
 
 
+class FormDataSerializer(BaseSerializer):
+
+    content_types = ['application/x-www-form-urlencoded']
+    key = "formdata"
+
+    def loads(self, data):
+        result = urlparse.parse_qs(data)
+        return result
+
+    def dumps(self, data):
+        result = urllib.urlencode(data)
+        return result
+
+
 class Serializer(object):
 
     def __init__(self, default=None, serializers=None):
@@ -70,7 +87,7 @@ class Serializer(object):
             default = "json" if _SERIALIZERS["json"] else "yaml"
 
         if serializers is None:
-            serializers = [x() for x in [JsonSerializer, YamlSerializer] if _SERIALIZERS[x.key]]
+            serializers = [x() for x in [JsonSerializer, YamlSerializer, FormDataSerializer] if _SERIALIZERS[x.key]]
 
         if not serializers:
             raise exceptions.SerializerNoAvailable("There are no Available Serializers.")

--- a/tests/resource.py
+++ b/tests/resource.py
@@ -12,7 +12,7 @@ from slumber import exceptions
 class ResourceTestCase(unittest.TestCase):
 
     def setUp(self):
-        self.base_resource = slumber.Resource(base_url="http://example/api/v1/test", format="json", append_slash=False)
+        self.base_resource = slumber.Resource(base_url="http://example/api/v1/test", format="json", input_format="json", append_slash=False)
 
     def test_get_200_json(self):
         r = mock.Mock(spec=requests.Response)
@@ -23,6 +23,7 @@ class ResourceTestCase(unittest.TestCase):
         self.base_resource._store.update({
             "session": mock.Mock(spec=requests.Session),
             "serializer": slumber.serialize.Serializer(),
+            "input_serializer": slumber.serialize.Serializer(),
         })
         self.base_resource._store["session"].request.return_value = r
 
@@ -52,6 +53,7 @@ class ResourceTestCase(unittest.TestCase):
         self.base_resource._store.update({
             "session": mock.Mock(spec=requests.Session),
             "serializer": slumber.serialize.Serializer(),
+            "input_serializer": slumber.serialize.Serializer(),
         })
         self.base_resource._store["session"].request.return_value = r
 
@@ -81,6 +83,7 @@ class ResourceTestCase(unittest.TestCase):
         self.base_resource._store.update({
             "session": mock.Mock(spec=requests.Session),
             "serializer": slumber.serialize.Serializer(),
+            "input_serializer": slumber.serialize.Serializer(),
         })
         self.base_resource._store["session"].request.return_value = r
 
@@ -114,6 +117,7 @@ class ResourceTestCase(unittest.TestCase):
         self.base_resource._store.update({
             "session": mock.Mock(spec=requests.Session),
             "serializer": slumber.serialize.Serializer(),
+            "input_serializer": slumber.serialize.Serializer(),
         })
         self.base_resource._store["session"].request.return_value = r
 
@@ -149,6 +153,7 @@ class ResourceTestCase(unittest.TestCase):
         self.base_resource._store.update({
             "session": mock.Mock(spec=requests.Session),
             "serializer": slumber.serialize.Serializer(),
+            "input_serializer": slumber.serialize.Serializer(),
         })
         self.base_resource._store["session"].request.side_effect = (r1, r2)
 
@@ -178,6 +183,7 @@ class ResourceTestCase(unittest.TestCase):
         self.base_resource._store.update({
             "session": mock.Mock(spec=requests.Session),
             "serializer": slumber.serialize.Serializer(),
+            "input_serializer": slumber.serialize.Serializer(),
         })
         self.base_resource._store["session"].request.return_value = r
 
@@ -212,6 +218,7 @@ class ResourceTestCase(unittest.TestCase):
         self.base_resource._store.update({
             "session": mock.Mock(spec=requests.Session),
             "serializer": slumber.serialize.Serializer(),
+            "input_serializer": slumber.serialize.Serializer(),
         })
         self.base_resource._store["session"].request.side_effect = (r1, r2)
 
@@ -241,6 +248,7 @@ class ResourceTestCase(unittest.TestCase):
         self.base_resource._store.update({
             "session": mock.Mock(spec=requests.Session),
             "serializer": slumber.serialize.Serializer(),
+            "input_serializer": slumber.serialize.Serializer(),
         })
         self.base_resource._store["session"].request.return_value = r
 
@@ -275,6 +283,7 @@ class ResourceTestCase(unittest.TestCase):
         self.base_resource._store.update({
             "session": mock.Mock(spec=requests.Session),
             "serializer": slumber.serialize.Serializer(),
+            "input_serializer": slumber.serialize.Serializer(),
         })
         self.base_resource._store["session"].request.side_effect = (r1, r2)
 
@@ -304,6 +313,7 @@ class ResourceTestCase(unittest.TestCase):
         self.base_resource._store.update({
             "session": mock.Mock(spec=requests.Session),
             "serializer": slumber.serialize.Serializer(),
+            "input_serializer": slumber.serialize.Serializer(),
         })
         self.base_resource._store["session"].request.return_value = r
 
@@ -327,6 +337,7 @@ class ResourceTestCase(unittest.TestCase):
     def test_handle_serialization(self):
         self.base_resource._store.update({
             "serializer": slumber.serialize.Serializer(),
+            "input_serializer": slumber.serialize.Serializer(),
         })
 
         resp = mock.Mock(spec=requests.Response)
@@ -348,6 +359,7 @@ class ResourceTestCase(unittest.TestCase):
         self.base_resource._store.update({
             "session": mock.Mock(spec=requests.Session),
             "serializer": slumber.serialize.Serializer(),
+            "input_serializer": slumber.serialize.Serializer(),
         })
 
         self.base_resource._store["session"].request.return_value = resp
@@ -363,6 +375,7 @@ class ResourceTestCase(unittest.TestCase):
         self.base_resource._store.update({
             "session": mock.Mock(spec=requests.Session),
             "serializer": slumber.serialize.Serializer(),
+            "input_serializer": slumber.serialize.Serializer(),
         })
         self.base_resource._store["session"].request.return_value = r
 
@@ -396,6 +409,7 @@ class ResourceTestCase(unittest.TestCase):
         self.base_resource._store.update({
             "session": mock.Mock(spec=requests.Session),
             "serializer": slumber.serialize.Serializer(),
+            "input_serializer": slumber.serialize.Serializer(),
         })
 
         self.base_resource._store["session"].request.return_value = r
@@ -413,6 +427,7 @@ class ResourceTestCase(unittest.TestCase):
         self.base_resource._store.update({
             "session": mock.Mock(spec=requests.Session),
             "serializer": slumber.serialize.Serializer(),
+            "input_serializer": slumber.serialize.Serializer(),
         })
         self.base_resource._store["session"].request.return_value = r
 
@@ -428,6 +443,7 @@ class ResourceTestCase(unittest.TestCase):
         self.base_resource._store.update({
             "session": mock.Mock(spec=requests.Session),
             "serializer": slumber.serialize.Serializer(),
+            "input_serializer": slumber.serialize.Serializer(),
         })
         self.base_resource._store["session"].request.return_value = r
 
@@ -474,6 +490,7 @@ class ResourceTestCase(unittest.TestCase):
         self.base_resource._store.update({
             "session": mock.Mock(spec=requests.Session),
             "serializer": slumber.serialize.Serializer(),
+            "input_serializer": slumber.serialize.Serializer(),
         })
         self.base_resource._store["session"].request.return_value = r
 
@@ -523,6 +540,7 @@ class ResourceTestCase(unittest.TestCase):
         self.base_resource._store.update({
             "session": mock.Mock(spec=requests.Session),
             "serializer": slumber.serialize.Serializer(),
+            "input_serializer": slumber.serialize.Serializer(),
         })
         self.base_resource._store["session"].request.return_value = r
 

--- a/tests/serializer.py
+++ b/tests/serializer.py
@@ -42,3 +42,24 @@ class ResourceTestCase(unittest.TestCase):
         result = serializer.dumps(self.data)
         self.assertEqual(result, "{foo: bar}\n")
         self.assertEqual(self.data, serializer.loads(result))
+
+    def test_formdata_get_serializer(self):
+        s = slumber.serialize.Serializer()
+
+        serializer = None
+        for content_type in [
+            "application/x-www-form-urlencoded",
+        ]:
+            serializer = s.get_serializer(content_type=content_type)
+            self.assertEqual(type(serializer), slumber.serialize.FormDataSerializer,
+                             "content_type %s should produce a FormDataSerializer")
+
+        result = serializer.dumps(self.data)
+        self.assertEqual(result, "foo=bar")
+
+        # The following would currently fail because parsing a query string
+        # leads to the values being lists instead of single items so you get:
+        #
+        #     {'foo': ['bar']}
+        #
+        # self.assertEqual(self.data, serializer.loads(result))


### PR DESCRIPTION
It would be nice to have a separate serializer for posted data from the data returned from the server.

This change:

 - incorporates commits from: https://bitbucket.org/newsletterfilter/slumber
 - resolves merge conflicts from the above
 - adjusts code to match current practice
 - adjusts tests
 - adds a simple test for the new serializer/deserializer
