### PR TITLE
Fix typo in example in docs that throws an error.

### DIFF
--- a/docs/options.rst
+++ b/docs/options.rst
@@ -105,7 +105,7 @@ An example::
 
     class PickleSerializer(slumber.serialize.BaseSerializer):
         key = "pickle"
-        content_type = "x-application/pickle"
+        content_types = "x-application/pickle"
 
         def loads(self, data):
             return pickle.loads(data)


### PR DESCRIPTION
The example in the doc has a typo. If the code is copied the user will receive the error:
```
Traceback (most recent call last):
  File "run.py", line 35, in <module>
    print api.healthcheck.get()
  File "/Users/xxx/.virtualenvs/aaq/lib/python2.7/site-packages/slumber/__init__.py", line 155, in get
    resp = self._request("GET", params=kwargs)
  File "/Users/xxx/.virtualenvs/aaq/lib/python2.7/site-packages/slumber/__init__.py", line 90, in _request
    headers = {"accept": serializer.get_content_type()}
  File "/Users/xxx/.virtualenvs/aaq/lib/python2.7/site-packages/slumber/serialize.py", line 109, in get_content_type
    return s.get_content_type()
  File "/Users/xxx/.virtualenvs/aaq/lib/python2.7/site-packages/slumber/serialize.py", line 26, in get_content_type
    raise NotImplementedError()
NotImplementedError
```