### PR TITLE
return JSON items in OrderedDict + tests

### DIFF
--- a/slumber/serialize.py
+++ b/slumber/serialize.py
@@ -15,6 +15,14 @@ try:
 except ImportError:
     _SERIALIZERS["yaml"] = False
 
+ordered_dict_defined = True
+try:
+    from collections import OrderedDict
+except ImportError:
+    try:
+        from ordereddict import OrderedDict
+    except ImportError:
+        ordered_dict_defined = False
 
 class BaseSerializer(object):
 
@@ -45,7 +53,10 @@ class JsonSerializer(BaseSerializer):
     key = "json"
 
     def loads(self, data):
-        return json.loads(data)
+        if ordered_dict_defined:
+            return json.loads(data, object_pairs_hook=OrderedDict)
+        else:
+            return json.loads(data)
 
     def dumps(self, data):
         return json.dumps(data)

--- a/tests/serializer.py
+++ b/tests/serializer.py
@@ -2,14 +2,29 @@ import unittest
 import slumber
 import slumber.serialize
 
+ordered_dict_defined = True
+try:
+    from collections import OrderedDict
+except ImportError:
+    try:
+        from ordereddict import OrderedDict
+    except ImportError:
+        ordered_dict_defined = False
+
 
 class ResourceTestCase(unittest.TestCase):
     def setUp(self):
         self.data = {
             "foo": "bar",
         }
+        if ordered_dict_defined:
+            self.data1 = OrderedDict((
+                ("foo", "bar"),
+                ("foo2", "bar"),
+                ("foo1", "bar"),
+            ))
 
-    def test_json_get_serializer(self):
+    def prepare_json_serializer(self):
         s = slumber.serialize.Serializer()
 
         serializer = None
@@ -23,10 +38,24 @@ class ResourceTestCase(unittest.TestCase):
             serializer = s.get_serializer(content_type=content_type)
             self.assertEqual(type(serializer), slumber.serialize.JsonSerializer,
                              "content_type %s should produce a JsonSerializer")
+        return serializer
+
+    def test_json_get_serializer(self):
+        serializer = self.prepare_json_serializer()
 
         result = serializer.dumps(self.data)
         self.assertEqual(result, '{"foo": "bar"}')
         self.assertEqual(self.data, serializer.loads(result))
+
+    def test_json_get_serializer_ordereddict(self):
+        if not ordered_dict_defined:  # skip this test if OrderedDict is not loaded
+            return
+
+        serializer = self.prepare_json_serializer()
+
+        result = serializer.dumps(self.data1)
+        self.assertEqual(result, '{"foo": "bar", "foo2": "bar", "foo1": "bar"}')
+        self.assertEqual(self.data1, serializer.loads(result))
 
     def test_yaml_get_serializer(self):
         s = slumber.serialize.Serializer()


### PR DESCRIPTION
This patch enables OrderedDict as JSON output, which makes possible to get REST feeds ordered in it's original order.
Tests are included.