### PR TITLE
Add supported language version classifiers

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -37,4 +37,13 @@ setup(
     install_requires = install_requires,
     tests_require = tests_require,
     test_suite = "tests.get_tests",
+    classifiers = [
+        'Programming Language :: Python :: 2',
+        'Programming Language :: Python :: 2.6',
+        'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.3',
+        'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: Implementation :: PyPy',
+    ],
 )


### PR DESCRIPTION
Updated the setup.py to correctly list the Python 2/3 support in the classifiers. Currently, it shows up as not supporting Python 3 on PyPI and related tools since no language versions are listed.  Information from https://travis-ci.org/samgiles/slumber